### PR TITLE
Check for different installed versions of msbuild

### DIFF
--- a/Setup/BuildInstallers.cmd
+++ b/Setup/BuildInstallers.cmd
@@ -2,7 +2,13 @@
 
 cd /d "%~p0"
 
-set msbuild="%programfiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
+set msbuild="%programfiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+if not exist %msbuild% (
+  set msbuild="%programfiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
+)
+if not exist %msbuild% (
+  set msbuild="%programfiles(x86)%\MSBuild\11.0\Bin\MSBuild.exe"
+)
 set project=..\GitExtensions.sln
 set projectShellEx=..\GitExtensionsShellEx\GitExtensionsShellEx.sln
 set projectSshAskPass=..\GitExtSshAskPass\GitExtSshAskPass.sln


### PR DESCRIPTION
After making this change, the build works with just VS 2015 installed.

Looking through the other branch changes though, I'm not 100% sure if it will work on VS 2012 and below since we're setting the tools version in the vcproj files to 12. With there being a free version of both VS 2013 and VS 2015, perhaps we shouldn't even support building the project in VS 2013 and below.
