### PR TITLE
FileAndForget should be only available for JoinableTask.

### DIFF
--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -72,7 +72,7 @@ namespace GitUI
             joinableTask.Task.FileAndForget(fileOnlyIf);
         }
 
-        public static void FileAndForget(this Task task, Func<Exception, bool> fileOnlyIf = null)
+        private static void FileAndForget(this Task task, Func<Exception, bool> fileOnlyIf = null)
         {
             JoinableTaskFactory.RunAsync(
                 async () =>

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -85,7 +85,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
             catch (Exception ex)
             {
-                this.InvokeSync(() =>
+                this.SendToUIThread(() =>
                     {
                         if (Visible)
                         {
@@ -118,7 +118,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void Done()
         {
-            this.InvokeSync(() =>
+            this.SendToUIThread(() =>
             {
                 progressBar1.Visible = false;
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -366,7 +366,7 @@ namespace GitUI.CommandsDialogs
 
         private void UICommands_PostRepositoryChanged(object sender, GitUIBaseEventArgs e)
         {
-            this.InvokeAsync(RefreshRevisions).FileAndForget();
+            this.PostToUIThread(RefreshRevisions);
         }
 
         private void RefreshRevisions()
@@ -463,13 +463,12 @@ namespace GitUI.CommandsDialogs
         private void _indexWatcher_Changed(object sender, IndexChangedEventArgs e)
         {
             bool indexChanged = e.IsIndexChanged;
-            this.InvokeAsync(() =>
+            this.PostToUIThread(() =>
             {
                 RefreshButton.Image = indexChanged && AppSettings.UseFastChecks && Module.IsValidGitWorkingDir()
                                           ? Resources.arrow_refresh_dirty
                                           : Resources.arrow_refresh;
-            })
-                .FileAndForget();
+            });
         }
 
         private bool _pluginsLoaded;
@@ -2759,7 +2758,7 @@ namespace GitUI.CommandsDialogs
 
         private void FormBrowse_Activated(object sender, EventArgs e)
         {
-            this.InvokeAsyncDoNotUseInNewCode(OnActivate);
+            this.PostToUIThread(OnActivate);
         }
 
         /// <summary>

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -225,13 +225,13 @@ namespace GitUI.CommitInfo
         private void LoadSortedRefs()
         {
             _sortedRefs = Module.GetSortedRefs().ToList();
-            this.InvokeAsyncDoNotUseInNewCode(UpdateRevisionInfo);
+            this.PostToUIThread(UpdateRevisionInfo);
         }
 
         private void LoadAnnotatedTagInfo(GitRevision revision)
         {
             _annotatedTagsMessages = GetAnnotatedTagsMessages(revision);
-            this.InvokeAsyncDoNotUseInNewCode(UpdateRevisionInfo);
+            this.PostToUIThread(UpdateRevisionInfo);
         }
 
         private IDictionary<string, string> GetAnnotatedTagsMessages(GitRevision revision)
@@ -287,7 +287,7 @@ namespace GitUI.CommitInfo
         private void LoadTagInfo(string revision)
         {
             _tags = Module.GetAllTagsWhichContainGivenCommit(revision).ToList();
-            this.InvokeAsyncDoNotUseInNewCode(UpdateRevisionInfo);
+            this.PostToUIThread(UpdateRevisionInfo);
         }
 
         private void LoadBranchInfo(string revision)
@@ -300,7 +300,7 @@ namespace GitUI.CommitInfo
             bool getRemote = AppSettings.CommitInfoShowContainedInBranchesRemote ||
                              AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal;
             _branches = Module.GetAllBranchesWhichContainGivenCommit(revision, getLocal, getRemote).ToList();
-            this.InvokeAsyncDoNotUseInNewCode(UpdateRevisionInfo);
+            this.PostToUIThread(UpdateRevisionInfo);
         }
 
         private void LoadLinksForRevision(GitRevision revision)
@@ -311,7 +311,7 @@ namespace GitUI.CommitInfo
             }
 
             _linksInfo = GetLinksForRevision(revision);
-            this.InvokeAsyncDoNotUseInNewCode(UpdateRevisionInfo);
+            this.PostToUIThread(UpdateRevisionInfo);
         }
 
         private class ItemTpComparer : IComparer<string>

--- a/GitUI/FormProcess.cs
+++ b/GitUI/FormProcess.cs
@@ -192,7 +192,7 @@ namespace GitUI
 
         private void OnExit(int exitcode)
         {
-            this.InvokeAsync(() =>
+            this.PostToUIThread(() =>
             {
                 bool isError;
                 try
@@ -210,7 +210,7 @@ namespace GitUI
                 }
 
                 Done(!isError);
-            }).FileAndForget();
+            });
         }
 
         protected virtual void DataReceived(object sender, TextEventArgs e)

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -105,7 +105,7 @@ namespace GitUI.UserControls
                 process.ErrorDataReceived += (sender, args) => FireDataReceived(new TextEventArgs((args.Data ?? "") + '\n'));
                 process.Exited += delegate
                 {
-                    this.InvokeAsync(() =>
+                    this.PostToUIThread(() =>
                     {
                         if (_process == null)
                         {
@@ -129,7 +129,7 @@ namespace GitUI.UserControls
                         _process = null;
                         _timer.Stop(true);
                         FireProcessExited();
-                    }).FileAndForget();
+                    });
                 };
 
                 process.Exited += (sender, args) =>

--- a/GitUI/UserControls/RevisionGrid.cs
+++ b/GitUI/UserControls/RevisionGrid.cs
@@ -1356,7 +1356,7 @@ namespace GitUI
         private void _revisionGraphCommand_Error(object sender, AsyncErrorEventArgs e)
         {
             // This has to happen on the UI thread
-            this.InvokeAsync(() =>
+            this.PostToUIThread(() =>
                                   {
                                       Error.Visible = true;
                                       ////Error.BringToFront();
@@ -1364,11 +1364,10 @@ namespace GitUI
                                       NoCommits.Visible = false;
                                       Revisions.Visible = false;
                                       Loading.Visible = false;
-                                  })
-                .FileAndForget();
+                                  });
 
             DisposeRevisionGraphCommand();
-            this.InvokeAsync(() => throw new AggregateException(e.Exception)).FileAndForget();
+            this.PostToUIThread(() => throw new AggregateException(e.Exception));
             e.Handled = true;
         }
 
@@ -1421,7 +1420,7 @@ namespace GitUI
                 !FilterIsApplied(true))
             {
                 // This has to happen on the UI thread
-                this.InvokeAsync(() =>
+                this.PostToUIThread(() =>
                                       {
                                           NoGit.Visible = false;
                                           NoCommits.Visible = true;
@@ -1429,13 +1428,12 @@ namespace GitUI
                                           Revisions.Visible = false;
                                           Loading.Visible = false;
                                           _isRefreshingRevisions = false;
-                                      })
-                    .FileAndForget();
+                                      });
             }
             else
             {
                 // This has to happen on the UI thread
-                this.InvokeAsync(() =>
+                this.PostToUIThread(() =>
                                       {
                                           UpdateGraph(null);
                                           Loading.Visible = false;
@@ -1445,8 +1443,7 @@ namespace GitUI
                                           {
                                               BuildServerWatcher.LaunchBuildServerInfoFetchOperation();
                                           }
-                                      })
-                    .FileAndForget();
+                                      });
             }
 
             DisposeRevisionGraphCommand();
@@ -2119,7 +2116,7 @@ namespace GitUI
             }
 
             // now that Body is filled (not null anymore) the revision grid can be refreshed to display the new information
-            this.InvokeAsyncDoNotUseInNewCode(() =>
+            this.PostToUIThread(() =>
             {
                 if (Revisions == null || Revisions.RowCount == 0 || Revisions.RowCount <= rowIndex || Revisions.RowCount != totalRowCount)
                 {

--- a/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
+++ b/GitUI/UserControls/RevisionGridClasses/DvcsGraph.cs
@@ -207,7 +207,7 @@ namespace GitUI.RevisionGridClasses
                     return;
                 }
 
-                this.InvokeSync(() =>
+                this.SendToUIThread(() =>
                     {
                         lock (_backgroundEvent)
                         {
@@ -539,12 +539,11 @@ namespace GitUI.RevisionGridClasses
         {
             // We have to post this since the thread owns a lock on GraphData that we'll
             // need in order to re-draw the graph.
-            this.InvokeAsync(() =>
+            this.PostToUIThread(() =>
                 {
                     ClearDrawCache();
                     Invalidate();
-                })
-                .FileAndForget();
+                });
         }
 
         public void dataGrid_CellPainting(object sender, DataGridViewCellPaintingEventArgs e)
@@ -652,7 +651,7 @@ namespace GitUI.RevisionGridClasses
                     // Update the row (if needed)
                     if (curCount == Math.Min(scrollTo, _visibleBottom) - 1)
                     {
-                        this.InvokeAsync(o => UpdateRow(o), curCount).FileAndForget();
+                        this.PostToUIThread(o => UpdateRow(o), curCount);
                     }
 
                     int count = 0;
@@ -663,7 +662,7 @@ namespace GitUI.RevisionGridClasses
 
                     if (curCount == count)
                     {
-                        this.InvokeAsync(UpdateColumnWidth).FileAndForget();
+                        this.PostToUIThread(UpdateColumnWidth);
                     }
 
                     curCount = _graphData.CachedCount;

--- a/UnitTests/GitUITests/ThreadHelperTests.cs
+++ b/UnitTests/GitUITests/ThreadHelperTests.cs
@@ -31,11 +31,7 @@ namespace GitUITests
             {
                 var ex = new Exception();
 
-                ThreadHelper.JoinableTaskFactory.Run(() =>
-                {
-                    ThrowExceptionAsync(ex).FileAndForget();
-                    return Task.CompletedTask;
-                });
+                ThrowExceptionAsync(ex).FileAndForget();
 
                 JoinPendingOperations();
                 Assert.AreSame(ex, helper.Exception);
@@ -50,11 +46,7 @@ namespace GitUITests
                 var form = new Form();
                 form.Dispose();
 
-                ThreadHelper.JoinableTaskFactory.Run(() =>
-                {
-                    YieldOntoControlMainThreadAsync(form).FileAndForget();
-                    return Task.CompletedTask;
-                });
+                YieldOntoControlMainThreadAsync(form).FileAndForget();
 
                 JoinPendingOperations();
                 Assert.Null(helper.Exception, helper.Message);
@@ -68,11 +60,7 @@ namespace GitUITests
             {
                 var ex = new Exception();
 
-                ThreadHelper.JoinableTaskFactory.Run(() =>
-                {
-                    ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e == ex);
-                    return Task.CompletedTask;
-                });
+                ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e == ex);
 
                 JoinPendingOperations();
                 Assert.AreSame(ex, helper.Exception);
@@ -86,11 +74,7 @@ namespace GitUITests
             {
                 var ex = new Exception();
 
-                ThreadHelper.JoinableTaskFactory.Run(() =>
-                {
-                    ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e != ex);
-                    return Task.CompletedTask;
-                });
+                ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e != ex);
 
                 JoinPendingOperations();
                 Assert.Null(helper.Exception, helper.Message);
@@ -105,11 +89,7 @@ namespace GitUITests
                 var form = new Form();
                 form.Dispose();
 
-                ThreadHelper.JoinableTaskFactory.Run(() =>
-                {
-                    YieldOntoControlMainThreadAsync(form).FileAndForget(fileOnlyIf: ex => true);
-                    return Task.CompletedTask;
-                });
+                YieldOntoControlMainThreadAsync(form).FileAndForget(fileOnlyIf: ex => true);
 
                 JoinPendingOperations();
                 Assert.Null(helper.Exception, helper.Message);

--- a/UnitTests/GitUITests/ThreadHelperTests.cs
+++ b/UnitTests/GitUITests/ThreadHelperTests.cs
@@ -31,7 +31,10 @@ namespace GitUITests
             {
                 var ex = new Exception();
 
-                ThrowExceptionAsync(ex).FileAndForget();
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await ThrowExceptionAsync(ex);
+                }).FileAndForget();
 
                 JoinPendingOperations();
                 Assert.AreSame(ex, helper.Exception);
@@ -46,7 +49,10 @@ namespace GitUITests
                 var form = new Form();
                 form.Dispose();
 
-                YieldOntoControlMainThreadAsync(form).FileAndForget();
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await YieldOntoControlMainThreadAsync(form);
+                }).FileAndForget();
 
                 JoinPendingOperations();
                 Assert.Null(helper.Exception, helper.Message);
@@ -60,7 +66,10 @@ namespace GitUITests
             {
                 var ex = new Exception();
 
-                ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e == ex);
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await ThrowExceptionAsync(ex);
+                }).FileAndForget(fileOnlyIf: e => e == ex);
 
                 JoinPendingOperations();
                 Assert.AreSame(ex, helper.Exception);
@@ -74,7 +83,10 @@ namespace GitUITests
             {
                 var ex = new Exception();
 
-                ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e != ex);
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await ThrowExceptionAsync(ex);
+                }).FileAndForget(fileOnlyIf: e => e != ex);
 
                 JoinPendingOperations();
                 Assert.Null(helper.Exception, helper.Message);
@@ -89,7 +101,10 @@ namespace GitUITests
                 var form = new Form();
                 form.Dispose();
 
-                YieldOntoControlMainThreadAsync(form).FileAndForget(fileOnlyIf: ex => true);
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await YieldOntoControlMainThreadAsync(form);
+                }).FileAndForget(fileOnlyIf: ex => true);
 
                 JoinPendingOperations();
                 Assert.Null(helper.Exception, helper.Message);

--- a/UnitTests/GitUITests/ThreadHelperTests.cs
+++ b/UnitTests/GitUITests/ThreadHelperTests.cs
@@ -28,7 +28,6 @@ namespace GitUITests
         public void FileAndForgetReportsThreadException()
         {
             using (var helper = new ThreadExceptionHelper())
-            using (var form = new Form())
             {
                 var ex = new Exception();
 
@@ -66,7 +65,6 @@ namespace GitUITests
         public void FileAndForgetFilterCanAllowExceptions()
         {
             using (var helper = new ThreadExceptionHelper())
-            using (var form = new Form())
             {
                 var ex = new Exception();
 
@@ -85,7 +83,6 @@ namespace GitUITests
         public void FileAndForgetFilterCanIgnoreExceptions()
         {
             using (var helper = new ThreadExceptionHelper())
-            using (var form = new Form())
             {
                 var ex = new Exception();
 


### PR DESCRIPTION
The way I simplified tests in https://github.com/sharwell/gitextensions/pull/4/commits/6ad3fab061aa37498b06e963dbb786a405bb7f4d is a proper usage of `FileAndForget`
Imagine a scenario:
```csharp
class MyForm : Form
{
  public void someMethod()
  {
    this.InvokeAsync(..).FileAndForget();
  }
}
```
And a test
```csharp
  [Test]
  public void someMethodTest()
  {
    var form = new MyForm();
    form.someMethod();
  }
```
I think it can lead to a deadlock the same way https://github.com/sharwell/gitextensions/pull/4/commits/6ad3fab061aa37498b06e963dbb786a405bb7f4d did.
